### PR TITLE
FFS-2167: header-basert Bearer-ingress-routing ved siden av SSO-cookie-flyt

### DIFF
--- a/kustomize/base/flais.yaml
+++ b/kustomize/base/flais.yaml
@@ -27,10 +27,15 @@ spec:
     hostname: flyt.vigoiks.no
     basePath: ""
   ingress:
-    enabled: true
-    basePath: path
-    middlewares:
-      - fint-flyt-auth-forward-sso
+    routes:
+      - host: flyt.vigoiks.no
+        path: path
+        headers:
+          Authorization: "re:.+"
+      - host: flyt.vigoiks.no
+        path: path
+        middlewares:
+          - fint-flyt-auth-forward-sso
   env:
     - name: JAVA_TOOL_OPTIONS
       value: '-XX:+ExitOnOutOfMemoryError -Xmx768M -Xms768M'

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "afk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/afk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/afk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "afk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/afk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/afk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "agderfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/agderfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/agderfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "agderfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/agderfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/agderfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/bfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/bfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/bfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/bfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bym.oslo.kommune.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/bym-oslo-kommune-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/bym-oslo-kommune-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ffk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/ffk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/ffk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ffk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/ffk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/ffk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "fintlabs.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/fintlabs-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/fintlabs-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "innlandetfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/innlandetfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/innlandetfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "innlandetfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/innlandetfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/innlandetfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "mrfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/mrfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/mrfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "nfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/nfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/nfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ofk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/ofk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/ofk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ofk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/ofk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/ofk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "rogfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/rogfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/rogfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "rogfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/rogfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/rogfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "telemarkfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/telemarkfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/telemarkfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "telemarkfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/telemarkfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/telemarkfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "tromsfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/tromsfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/tromsfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "tromsfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/tromsfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/tromsfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "trondelagfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/trondelagfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/trondelagfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "trondelagfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/trondelagfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/trondelagfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vestfoldfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/vestfoldfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/vestfoldfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vestfoldfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/vestfoldfylke-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/vestfoldfylke-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vlfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/vlfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/vlfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vlfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/vlfk-no/api/intern/konfigurasjoner"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/vlfk-no/api/intern/konfigurasjoner"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "$ORG_ID"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "$INGRESS_BASE_PATH"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "$INGRESS_BASE_PATH"
       - op: add
         path: "/spec/env/-"


### PR DESCRIPTION
## Summary
- Erstatter `ingress.enabled/basePath/middlewares` med `ingress.routes` i `kustomize/base/flais.yaml`: to ruter på samme host+path — én med `headers: {Authorization: "re:.+"}` og ingen middleware, én fallback med `middlewares: [fint-flyt-auth-forward-sso]`.
- Requests med `Authorization: Bearer` (M2M client-credentials og en fremtidig omskrevet frontend) treffer resource-serveren direkte, uten å gå via SSO-forwardAuth-middlewaren `fint-flyt-auth-forward-sso` (som i dag krever `user_session`-cookie og ellers svarer 307 mot IDP). SSO-cookie-flyten er uendret via fallback-ruten.
- `kustomize/templates/overlay.yaml.tpl` patcher nå `/spec/ingress/routes/0/path` og `/spec/ingress/routes/1/path` i stedet for `/spec/ingress/basePath`.
- Alle overlays regenerert med `./scripts/render-overlay.sh`.
- Ren ingress-konfig, ingen backend-kodeendring — tjenesten er allerede OAuth2 resource server (`no.novari:flyt-web-resource-server`) og validerer JWT uavhengig av hvordan token kom inn.
- Samme mønster som allerede rullet ut i `fint-flyt-authorization-service` (FFS-2166).

Del av epic FFS-2164.