### PR TITLE
FFS-2233: Rull ut OpenTelemetry-sporing (HTTP og Kafka)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,12 +59,14 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0")
-    implementation("no.novari:flyt-kafka:7.2.0")
+    implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
+    implementation("no.novari:flyt-kafka:7.3.0-rc-2")
     implementation("no.novari:flyt-audit-starter:1.1.0")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     kapt("org.springframework.boot:spring-boot-configuration-processor")

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/afk-no"
       - op: replace

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -39,8 +39,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "afk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/agderfk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "agderfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/bfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -39,8 +39,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "bfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 
 labels:
   - pairs:
-      app.kubernetes.io/instance: fint-flyt-configuration-service_bym_oslo_kommune_no
+      app.kubernetes.io/instance: fint-flyt-configuration-service_bym-oslo-kommune-no
       fintlabs.no/org-id: bym.oslo.kommune.no
 
 patches:
@@ -30,7 +30,7 @@ patches:
           name: "novari.flyt.web-resource-server.security.api.internal.authorized-org-id-role-pairs-json"
           value: |
             {
-              "bym.oslo.kommune.no":["USER"],
+              "bym-oslo-kommune.no":["USER"],
               "vigo.no":["DEVELOPER", "USER"],
               "novari.no":["DEVELOPER", "USER"]
             }

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 
 labels:
   - pairs:
-      app.kubernetes.io/instance: fint-flyt-configuration-service_bym-oslo-kommune-no
+      app.kubernetes.io/instance: fint-flyt-configuration-service_bym_oslo_kommune_no
       fintlabs.no/org-id: bym.oslo.kommune.no
 
 patches:
@@ -30,7 +30,7 @@ patches:
           name: "novari.flyt.web-resource-server.security.api.internal.authorized-org-id-role-pairs-json"
           value: |
             {
-              "bym-oslo-kommune.no":["USER"],
+              "bym.oslo.kommune.no":["USER"],
               "vigo.no":["DEVELOPER", "USER"],
               "novari.no":["DEVELOPER", "USER"]
             }
@@ -39,6 +39,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "bym-oslo-kommune-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "bym.oslo.kommune.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ffk-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "ffk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "fintlabs-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "fintlabs.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "innlandetfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "mrfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/mrfylke-no"
       - op: replace

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "nfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/nfk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ofk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -39,8 +39,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "ofk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/rogfk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "rogfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "telemarkfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "tromsfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "trondelagfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "vestfoldfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vlfk-no"
       - op: replace

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -37,8 +37,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "vlfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -29,11 +29,16 @@ patches:
         value:
           name: "novari.flyt.web-resource-server.security.api.internal.authorized-org-id-role-pairs-json"
           value: |$ROLE_MAP
-      - op: add
+$OTEL_ENV_PATCH      - op: add
         path: "/spec/env/-"
         value:
          name: "novari.kafka.topic.orgId"
          value: "$FINT_KAFKA_TOPIC_ORGID"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "$ORG_ID"
       - op: add
         path: "/spec/env/-"
         value:

--- a/scripts/render-overlay.sh
+++ b/scripts/render-overlay.sh
@@ -5,6 +5,21 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMPLATE_DIR="$ROOT/kustomize/templates"
 BASE_TEMPLATE="$TEMPLATE_DIR/overlay.yaml.tpl"
 
+OTEL_ENDPOINT_BETA="http://alloy.flais-system.svc.cluster.local:4318"
+
+# Base-URL uten /v1/traces: telemetry-starter legger på signal-stien selv.
+# Settes manuelt inntil FLAIS har konfigurert dette som plattform-standard, og kun i beta.
+build_otel_env_patch() {
+  local env_name="$1"
+
+  if [[ "$env_name" != "beta" ]]; then
+    return
+  fi
+
+  printf '      - op: add\n        path: "/spec/env/-"\n        value:\n          name: "OTEL_EXPORTER_OTLP_ENDPOINT"\n          value: "%s"' \
+    "$OTEL_ENDPOINT_BETA"
+}
+
 while IFS= read -r file; do
   rel="${file#"$ROOT/kustomize/overlays/"}"
   dir="$(dirname "$rel")"
@@ -58,6 +73,12 @@ EOF
   role_map_lines="$(printf '%s\n' "$role_map_json" | sed 's/^/          /')"
   ROLE_MAP=$'\n'"$role_map_lines"
 
+  OTEL_ENV_PATCH=""
+  otel_patch_body="$(build_otel_env_patch "$env_name")"
+  if [[ -n "$otel_patch_body" ]]; then
+    OTEL_ENV_PATCH="${otel_patch_body}"$'\n'
+  fi
+
   export NAMESPACE="$namespace"
   export ORG_ID="$org_id"
   export APP_INSTANCE="$app_instance"
@@ -70,6 +91,7 @@ EOF
   export METRICS_PATH="$metrics_path"
   export ROLE_MAP
   export FINT_KAFKA_TOPIC_ORGID="$namespace"
+  export OTEL_ENV_PATCH
 
   tmp="$(mktemp)"
   envsubst < "$BASE_TEMPLATE" > "$tmp"

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,8 @@ server:
   max-http-request-header-size: 40KB
 
 spring:
+  application:
+    name: ${fint.application-id}
   profiles:
     include:
       - flyt-kafka

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Sammendrag

Ruller ut OpenTelemetry-sporing til `fint-flyt-configuration-service`, del av epicen [FFS-2196](https://novari-iks.atlassian.net/browse/FFS-2196). Se [FFS-2233](https://novari-iks.atlassian.net/browse/FFS-2233). Samme mønster som allerede rullet ut til `fint-flyt-egrunnerverv-gateway`, `fint-flyt-file-service`, `fint-flyt-authorization-service` og `fint-flyt-instance-service`.

- Bumper `no.novari:flyt-web-resource-server` fra `4.0.0` til `4.1.0-rc-2` og `no.novari:flyt-kafka` fra `7.2.0` til `7.3.0-rc-2`, og legger til `no.novari:telemetry-starter:0.0.4` som ny avhengighet. RC-versjonene brukes fordi den opprinnelige utrullingen (FFS-2223–2226) ikke er 100 % ferdig verifisert i produksjon ennå.
- Setter `spring.application.name` slik at spans navngis riktig i Tempo/Grafana i stedet for å havne under `unknown_service`.
- Aktiverer `novari.kafka.tracing.enabled` i `flyt-kafka`-profilen. Denne er av som standard i det delte Kafka-biblioteket for ikke å endre oppførsel for andre team.
- Utvider `kustomize/templates/overlay.yaml.tpl` og `scripts/render-overlay.sh` med et `novari.telemetry.org-id`-patch (alle overlays) og et betinget `OTEL_EXPORTER_OTLP_ENDPOINT`-patch (kun beta, inntil FLAIS setter dette som plattform-standard), og regenererer alle 28 overlays med scriptet. Verifisert med `kustomize build` før og etter — diffene inneholder kun de nye env-variablene.
- Legger til strukturert JSON-logging (`logback.xml` som inkluderer telemetry-starterens `logback-json.xml`), slik at trace-/span-ID blir egne loggfelt.

`./gradlew check` er grønt, inkludert ktlint og integrasjonstester mot ekte Postgres/Kafka via testcontainers.

[FFS-2196]: https://novari-iks.atlassian.net/browse/FFS-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FFS-2233]: https://novari-iks.atlassian.net/browse/FFS-2233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ